### PR TITLE
Update dependencies to include extlib version 2

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppet/extlib",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
+      "version_requirement": ">= 1.0.0 < 3.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
This module works fine with extlib version 2. This updates the dependencies to include version 2 of extlib