### PR TITLE
Add basic RedHat/Fedora support

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -27,11 +27,20 @@ class vim::config {
   }
 
   if $::vim::default_editor {
+    # Fedora/RedHat systems don't have /etc/alternatives/editor out of the box.
+    # The below settings match those used in Debian 9
+    exec { 'add-editor-alternative':
+      path    => '/usr/bin:/usr/sbin/:/bin:/sbin',
+      command => "update-alternatives --install /usr/bin/editor editor ${::vim::vim_path} 30",
+      unless  => 'test -L /etc/alternatives/editor',
+      require => $::vim::config_file_require,
+    }
+
     exec { 'update-alternatives':
       path    => '/usr/bin:/usr/sbin/:/bin:/sbin',
-      command => 'update-alternatives --set editor /usr/bin/vim.basic',
-      unless  => 'test /etc/alternatives/editor -ef /usr/bin/vim.basic',
-      require => $::vim::config_file_require,
+      command => "update-alternatives --set editor ${::vim::vim_path}",
+      unless  => "test /etc/alternatives/editor -ef ${::vim::vim_path}",
+      require => Exec['add-editor-alternative'],
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,7 @@ class vim (
   $package_name             = $::vim::params::package_name,
   $package_list             = $::vim::params::package_list,
 
+  $vim_path                 = $::vim::params::vim_path,
   $config_dir_path          = $::vim::params::config_dir_path,
   $config_dir_purge         = false,
   $config_dir_recurse       = true,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,11 +9,17 @@ class vim::params {
     default => undef,
   }
 
+  $vim_path = $::osfamily ? {
+    'RedHat' => '/usr/bin/vim',
+    default => '/usr/bin/vim.basic',
+  }
+
   $config_dir_path = $::osfamily ? {
     default => '/etc/vim',
   }
 
   $config_file_path = $::osfamily ? {
+    'RedHat' => '/etc/vimrc',
     default => '/etc/vim/vimrc',
   }
 
@@ -35,6 +41,8 @@ class vim::params {
 
   case $::osfamily {
     'Debian': {
+    }
+    'RedHat': {
     }
     default: {
       fail("${::operatingsystem} not supported.")


### PR DESCRIPTION
This commit fixes various small issues to enable support for RedHat/Fedora. This has been tested on Fedora 29, but it should work on any RedHat-based distro, at least from CentOS 6 upwards. I also regression-tested this on Debian 9.

The key differences in RedHat/Fedora compared to Debian/Ubuntu:
- /etc/alternatives/editor is not present (added if needed)
- /etc/vim directory is not present (not added, not sure if it affects anything in practice)

My own usage of this module has been quite simplistic:
```
    class { '::vim':
        config_file_source => 'puppet:///files/vimrc.local',
    }

```
If you want me to test other invocations as well just let me know.